### PR TITLE
fix CphTest with number arguments

### DIFF
--- a/lua/cphelper/process_tests.lua
+++ b/lua/cphelper/process_tests.lua
@@ -27,7 +27,7 @@ local function iterate_cases(case_numbers)
         end
     else
         for _, case in ipairs(case_numbers) do
-            local case_display, success = run.run_test("input" .. case, def.run_cmd[ft])
+            local case_display, success = run.run_test(case, def.run_cmd[ft])
             vim.list_extend(display, case_display)
             ac = ac + success
             cases = cases + 1


### PR DESCRIPTION
This pull request fixes an issue when using `CphTest` with arguments.

Running `CphTest 1` gives the following error:
```
E5108: Error executing lua Vim:E484: Can't open file inputinput1
stack traceback:
        [C]: in function 'readfile'
        ...ack/packer/start/cphelper.nvim/lua/cphelper/run_test.lua:15: in function 'run_test'
        ...acker/start/cphelper.nvim/lua/cphelper/process_tests.lua:30: in function 'iterate_cases'
        ...acker/start/cphelper.nvim/lua/cphelper/process_tests.lua:102: in function 'process_retests'
        ...acker/start/cphelper.nvim/lua/cphelper/process_tests.lua:94: in function 'process'
        [string ":lua"]:1: in main chunk
Press ENTER or type command to continue
```
It seems like the `case` variable was already the complete filename, so by prepending "input", we ended up with `inputinput1` as filename, which doesn't exist. I just removed the prepending part of the code.